### PR TITLE
Rarity button refactor

### DIFF
--- a/src/components/SetDetails/CardList.js
+++ b/src/components/SetDetails/CardList.js
@@ -44,8 +44,6 @@ function CardList({ setId }) {
         if (rarityOption.length < 1 || rarityOption.length > 3)
             rarityOption = undefined;
 
-        console.log(rarityOption)
-
         // Put all search options into a single object for findCards function
         const searchOptions = {set: setId, color: colors, booster: true, rarity: rarityOption, term: searchTerm};
 

--- a/src/components/SetDetails/CardList.js
+++ b/src/components/SetDetails/CardList.js
@@ -19,7 +19,7 @@ function CardList({ setId }) {
     const cardCollection = useSelector(state => state.inventory.cardCollection);
     const colors         = useSelector(state => state.displayOptions.colors);
     const searchTerm     = useSelector(state => state.displayOptions.searchTerm);
-    const rarity         = useSelector(state => state.displayOptions.rarity);
+    const rarities       = useSelector(state => state.displayOptions.rarity);
     const showCards      = useSelector(state => state.displayOptions.showCards);
     const cardCount      = useSelector(state => state.displayOptions.cardCount);
 
@@ -29,8 +29,22 @@ function CardList({ setId }) {
     // Get the cards using the findCards Function
     const cards = useMemo(() => {
 
-        // If rarity is set to all, set rarityOption to undefined so findCards will not filter by rarity
-        const rarityOption = rarity !== 'all' ? [rarity] : undefined;
+        // If all/none of the rarities selected, set rarityOption to undefined so findCards will not filter by rarity
+        let rarityOption = []; let index = 0;
+        for (const rarity in rarities) {
+
+            // Add rarity to rarityOption if it's selected
+            if (rarities[rarity]) {
+                rarityOption[index] = rarity;
+                index++;
+            }
+        }
+
+        // Set rarityOption to undefined if all or none of the rarities are added to it
+        if (rarityOption.length < 1 || rarityOption.length > 3)
+            rarityOption = undefined;
+
+        console.log(rarityOption)
 
         // Put all search options into a single object for findCards function
         const searchOptions = {set: setId, color: colors, booster: true, rarity: rarityOption, term: searchTerm};
@@ -40,7 +54,7 @@ function CardList({ setId }) {
 
         return findCards(searchOptions, returnOptions);
         
-    }, [colors, searchTerm, setId, rarity]);
+    }, [colors, searchTerm, setId, rarities]);
 
     // Track currently shown pictures
     let currentPictures = [];

--- a/src/components/SetDetails/CustomButton.js
+++ b/src/components/SetDetails/CustomButton.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { useDispatch } from 'react-redux';
 
 /**
@@ -14,8 +14,22 @@ export default function CustomButton({ action, value, className="", text=value }
     // Access redux reducer
     const dispatch = useDispatch();
 
+    // Add a ref to blur button
+    const ref = useRef();
+
     return (
-        <button className={className} onClick={() => dispatch(action(value))} >
+        <button 
+            className={className}
+            ref={ref}
+            onClick={ () => {
+
+                // Dispatch the action
+                dispatch(action(value));
+
+                // Deselect the button
+                ref.current.blur();
+            } }
+        >
             {text}
         </button>
     );

--- a/src/components/SetDetails/DisplayOptions.js
+++ b/src/components/SetDetails/DisplayOptions.js
@@ -10,7 +10,7 @@ import '../../css/DisplayOptions.css';
 function DisplayOptions() {
 
     const showCards = useSelector(state => state.displayOptions.showCards);
-    const raritySelected = useSelector(state => state.displayOptions.rarity);
+    const rarities  = useSelector(state => state.displayOptions.rarity);
 
     const showListButtons = [
         {value: "=0",  text: "None"},
@@ -32,22 +32,21 @@ function DisplayOptions() {
             />
         );
     });
-
-    const rarityButtons = [
-        {value: 'mythic'},
-        {value: 'rare'},
-        {value: 'uncommon'},
-        {value: 'common'},
-        {value: 'all'}
-    ];
     
-    const renderRarityButtons = rarityButtons.map((button) => {
-        let buttonClass = `ui button primary rarityButton ${button.value}`;
-        if ( button.value !== raritySelected) {
+    // Create array of rarity buttons
+    const renderRarityButtons = [];
+
+    // Loop through each rarity and check whether it's currently selected
+    for (const rarity in rarities) {
+        let buttonClass = `ui button primary rarityButton ${rarity}`;
+
+        // If the rarity isn't currently selected, add "basic" to its class
+        if ( !rarities[rarity] )
             buttonClass += ' basic';
-        }
-        return <CustomButton action={selectRarity} className={buttonClass} value={button.value} key={button.value} />
-    });
+        
+        // Then push that rarity button to the array
+        renderRarityButtons.push(<CustomButton action={selectRarity} className={buttonClass} value={rarity} key={rarity} />);
+    }
 
     return (<div className="DisplayOptions">
         <SearchBar/>

--- a/src/reducers/displayOptionsReducer.js
+++ b/src/reducers/displayOptionsReducer.js
@@ -13,7 +13,7 @@ const INITIAL_STATE = {
         colorless: false
     },
 
-    rarity: "all",
+    rarity: { common: false, uncommon: false, rare: false, mythic: false },
     
     showCards: "all",
 
@@ -50,9 +50,14 @@ export default function displayOptionsReducer(state = INITIAL_STATE, action) {
             return newState;
         }
 
-        // Rarity must be one of: { common, uncommon, rare, mythic, all }
+        // Rarity can be any of: { common, uncommon, rare, mythic }
         case SELECT_RARITY: {
-            return { ...state, rarity: action.payload };
+            const newState = {...state};
+
+            // Flip value of the input rarity
+            newState.rarity[action.payload] = !newState.rarity[action.payload];
+
+            return newState;
         }
 
         // showCards must be one of: { unowned, owned, all }

--- a/src/reducers/displayOptionsReducer.js
+++ b/src/reducers/displayOptionsReducer.js
@@ -52,12 +52,12 @@ export default function displayOptionsReducer(state = INITIAL_STATE, action) {
 
         // Rarity can be any of: { common, uncommon, rare, mythic }
         case SELECT_RARITY: {
-            const newState = {...state};
+            const rarity = {...state.rarity};
 
             // Flip value of the input rarity
-            newState.rarity[action.payload] = !newState.rarity[action.payload];
+            rarity[action.payload] = !rarity[action.payload];
 
-            return newState;
+            return {...state, rarity};
         }
 
         // showCards must be one of: { unowned, owned, all }


### PR DESCRIPTION
- "All" option removed and each rarity is selectable independent of the others. Can have any/all rarities selected. Having all or none of the rarities selected elicits identical behavior - namely, showing all cards independent of rarity.

- The back end search is optimized by supplying the value "undefined" for the rarity search when either all or none of the rarities are selected. The value of "undefined" causes the rarity search not to occur, expediting the search.