### PR TITLE
Lazy load

### DIFF
--- a/src/components/All/CardList.js
+++ b/src/components/All/CardList.js
@@ -152,6 +152,9 @@ function CardList({ setId=null }) {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [renderCards] );
     
+    // View width = inner width of window - scrollbar width - card list margin
+    const viewWidth = window.innerWidth - 17 - 2*20;
+
     return (<>
         {/* Counter for number of cards being displayed */}
         <p id="displayingNumberCards">
@@ -160,7 +163,7 @@ function CardList({ setId=null }) {
 
         {/* JSX for matching cards */}
         <div className="cardList-cards">
-            <LazyLoad childWidth={245} childHeight={351.75} viewWidth={window.innerWidth} emptyChildClass="bouncy column" >
+            <LazyLoad childWidth={225} childHeight={351.75} gap={20} viewWidth={viewWidth}>
                 {renderCards}
             </LazyLoad>
         </div>

--- a/src/components/All/CardList.js
+++ b/src/components/All/CardList.js
@@ -159,9 +159,8 @@ function CardList({ setId=null }) {
         </p>
 
         {/* JSX for matching cards */}
-
         <div className="cardList-cards">
-            <LazyLoad childWidth={245} childHeight={351.75} viewWidth={window.innerWidth} >
+            <LazyLoad childWidth={245} childHeight={351.75} viewWidth={window.innerWidth} emptyChildClass="bouncy column" >
                 {renderCards}
             </LazyLoad>
         </div>

--- a/src/components/All/CardList.js
+++ b/src/components/All/CardList.js
@@ -8,6 +8,7 @@ import { updateImageList } from '../../actions';
 import '../../css/CardList.css';
 
 /**
+ * The list of MTG Arena cards.
  * 
  * @param {string} [setId=null] (Optional) three letter set code. Can also specify using redux.
  * @returns Returns a grid of images of card in the set using filter options that are retrieved from redux store. Also displays the number

--- a/src/components/All/CardList.js
+++ b/src/components/All/CardList.js
@@ -3,6 +3,7 @@ import { useSelector, useDispatch } from 'react-redux';
 
 import findCards from '../../data/findCards';
 import CardListImage from './CardListImage';
+import LazyLoad from '../Templates/LazyLoad';
 import { updateImageList } from '../../actions';
 import '../../css/CardList.css';
 
@@ -160,7 +161,9 @@ function CardList({ setId=null }) {
         {/* JSX for matching cards */}
 
         <div className="cardList-cards">
-            {renderCards}  
+            <LazyLoad childWidth={245} childHeight={351.75} viewWidth={window.innerWidth} >
+                {renderCards}
+            </LazyLoad>
         </div>
     </>);
 }

--- a/src/components/Templates/LazyLoad.js
+++ b/src/components/Templates/LazyLoad.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useMemo } from 'react';
 
 /**
  * Doesn't allow children to be rendered to the DOM until they are within about one 'view height' of the parent element.
+ * Assumes that all child elements are the same size.
  * 
  * @prop {number} childHeight Height of child elements, including margin/padding.
  * @prop {number} childWidth Width of child elements, including margin/padding.

--- a/src/components/Templates/LazyLoad.js
+++ b/src/components/Templates/LazyLoad.js
@@ -1,6 +1,10 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 
-
+/**
+ * 
+ * @param {Number} props.childHeight
+ * @returns 
+ */
 function LazyLoad(
     { children, childHeight, childWidth, viewHeight=window.innerHeight, viewWidth=window.innerWidth }
 ) {
@@ -8,13 +12,16 @@ function LazyLoad(
     // Track number of children currently shown
     const [numChildrenShown, setNumChildrenShown] = useState(12);
 
+    // Avoid recomputing number of children per row/column when not needed
+    const childrenPerRow = useMemo(() => Math.floor(viewWidth/childWidth), [viewWidth, childWidth]);
+    const height = useMemo(() => (children.length/childrenPerRow * childHeight), [children, childrenPerRow, childHeight]);
+
     // Add listener for Y scrolling
     useEffect(() => {
         function onScrollY() {
 
             // Calculate number of children to show
-            const numChildrenWeNeedToShow = Math.ceil( Math.ceil((window.scrollY + viewHeight) / childHeight) * Math.floor(viewWidth/childWidth) );
-            console.log(numChildrenWeNeedToShow)
+            const numChildrenWeNeedToShow = Math.ceil((window.scrollY + viewHeight) / childHeight) * childrenPerRow;
 
             // Increment number of children to show if user scrolls down
             if (numChildrenWeNeedToShow > numChildrenShown) {
@@ -22,14 +29,21 @@ function LazyLoad(
             }
         }
 
+        //TODO: clean up event listener when done, call less often?, load more than a row at a time?, track scrollY?
+
         // Track scrolling
         window.addEventListener("scroll", onScrollY);
 
         // Cleanup
         return () => window.removeEventListener("scroll", onScrollY);
-    }, [childHeight, childWidth, viewWidth, viewHeight, numChildrenShown]);
+    }, [childHeight, viewHeight, childrenPerRow, numChildrenShown]);
 
-    return children.slice(0, numChildrenShown);
+    // Set height of lazyload div so scroll bar shows true length
+    return <div className="lazyLoad" style={{ "height" : {height} }} >
+
+        {/* Only show children if they've been scrolled to */ }
+        {children.slice(0, numChildrenShown)}
+    </div>
 }
 
 export default LazyLoad;

--- a/src/components/Templates/LazyLoad.js
+++ b/src/components/Templates/LazyLoad.js
@@ -24,7 +24,7 @@ function LazyLoad(
 ) {
     
     // Track number of children currently shown
-    const [numChildrenShown, setNumChildrenShown] = useState(12);
+    const [numChildrenShown, setNumChildrenShown] = useState(numberInitiallyShown);
 
     // Get parent element
     const parent = forwardedParentRef ? forwardedParentRef.current : window;

--- a/src/components/Templates/LazyLoad.js
+++ b/src/components/Templates/LazyLoad.js
@@ -1,77 +1,88 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 
-/**
- * 
- * @param {Number} props.childHeight
- * @returns 
- */
+// parent width/height will typically use window.innerWidth/.innerHeight as a variable (remember the width of the scrollbar)
+// parent and child width/height must have margins factored in
 function LazyLoad(
-    { children, childHeight, childWidth, viewHeight=window.innerHeight, viewWidth=window.innerWidth }
+    { 
+        children, childHeight, childWidth, viewWidth, gap=0,
+        viewHeight=window.innerHeight, forwardedParentRef=null 
+    }
 ) {
     
     // Track number of children currently shown
     const [numChildrenShown, setNumChildrenShown] = useState(12);
 
-    // Avoid recomputing number of children per row/column when not needed
-    const childrenPerRow = useMemo(() => Math.floor(viewWidth/childWidth), [viewWidth, childWidth]);
-    const height = useMemo(() => (children.length/childrenPerRow * childHeight), [children, childrenPerRow, childHeight]);
+    // Calculate the number of children that can fit in a row
+    const childrenPerRow = useMemo(() => {
+
+        // From: NumberChildren * ChildWidth + (NumberChildren - 1) * GapWidth <= ParentWidth
+        return Math.floor( (viewWidth + gap) / (childWidth + gap) );
+    }, [viewWidth, childWidth, gap]);
+
+    // Calculate container height to set so scrollbar is about the right size
+    const height = useMemo(() => {
+
+        return Math.ceil(children.length/childrenPerRow) * childHeight;
+    }, [children, childrenPerRow, childHeight]);
+
+    // Track whether the throttle function is currently active
+    const throttleActive = useRef(false); // throttleActive.current = false;
 
     // Add listener for Y scrolling on page load or resize
     useEffect(() => {
         
         // Watch for scrolling and compute number of children to show
-        function onScrollY() {
+        function onScrollY() { // Function to throttle
 
-            throttle(() => { // Function to throttle
+            // Calculate number of children to show
+            const numChildrenWeNeedToShow = Math.ceil((window.scrollY + viewHeight) / childHeight) * childrenPerRow;
 
-                // Calculate number of children to show
-                const numChildrenWeNeedToShow = Math.ceil((window.scrollY + viewHeight) / childHeight) * childrenPerRow;
-    
-                // Increment number of children to show if user scrolls down
-                if (numChildrenWeNeedToShow > numChildrenShown) {
-                    setNumChildrenShown(numChildrenWeNeedToShow);
-                }
-
-            }, 200); // Delay
-
-        }
-
-        // Create a timer id
-        let id;
-
-        // Throttle scrolling event function
-        function throttle(throttledFunction, delay) {
-
-            // Do nothing if the timeout hasn't completed yet (otherwise id would be undefined)
-            if (id) {
-                return;
+            // Increment number of children to show if user scrolls down
+            if (numChildrenWeNeedToShow > numChildrenShown) {
+                setNumChildrenShown(numChildrenWeNeedToShow);
             }
-
-            // Call {throttledFunction} after {delay} and set timeout id
-            id = setTimeout(() => {
-
-                // Run the throttled function after the delay
-                throttledFunction();
-
-                // And clear the timer id
-                id = undefined;
-            }, delay);
         }
 
-        //TODO: clean up event listener when done, call less often?, load more than a row at a time?, track scrollY?
+        /**
+         * Allows the "throttledFunction" to be run, at most, every "delay" milliseconds.
+         * Ignores susequent calls to "throttledFunction" within the delay period.
+         * 
+         * @param {function} throttledFunction Function to throttle
+         * @param {number} delay Number of milliseconds to throttle "throttledFunction"
+         */
+         function throttle(throttledFunction, delay) {
+
+            // Only accept new function call when throttle is not active
+            if (!throttleActive.current) {
+
+                // Set throttle to active state
+                throttleActive.current = true;
+
+                // After "delay" milliseconds, run the throttledFunction and clear "active" status of throttle
+                setTimeout(() => {
+
+                    // Clear the active status of throttle
+                    throttleActive.current = false;
+
+                    // Run the throttled function
+                    throttledFunction();
+                }, delay);
+            }
+        }
+
+        // Throttle onScrollY so it's only called, at most, every 200ms
+        const throttledOnScrollY = ( () => throttle(onScrollY, 200) );
 
         // Track scrolling
-        window.addEventListener("scroll", onScrollY);
+        window.addEventListener("scroll", throttledOnScrollY);
         
         // Cleanup
-        return () => window.removeEventListener("scroll", onScrollY);
+        return () => window.removeEventListener("scroll", throttledOnScrollY);
 
     }, [childHeight, childrenPerRow, numChildrenShown, viewHeight]);
-    
-    
 
     // Set height of lazyload div so scroll bar shows true length
-    return <div className="lazyLoad" style={{ "height" : {height} }} >
+    return <div className="lazyLoad" style={{ "minHeight" : `${height}px` }} >
 
         {/* Only show children if they've been scrolled to */ }
         {children.slice(0, numChildrenShown)}

--- a/src/components/Templates/LazyLoad.js
+++ b/src/components/Templates/LazyLoad.js
@@ -1,0 +1,35 @@
+import { useState, useEffect } from 'react';
+
+
+function LazyLoad(
+    { children, childHeight, childWidth, viewHeight=window.innerHeight, viewWidth=window.innerWidth }
+) {
+    
+    // Track number of children currently shown
+    const [numChildrenShown, setNumChildrenShown] = useState(12);
+
+    // Add listener for Y scrolling
+    useEffect(() => {
+        function onScrollY() {
+
+            // Calculate number of children to show
+            const numChildrenWeNeedToShow = Math.ceil( Math.ceil((window.scrollY + viewHeight) / childHeight) * Math.floor(viewWidth/childWidth) );
+            console.log(numChildrenWeNeedToShow)
+
+            // Increment number of children to show if user scrolls down
+            if (numChildrenWeNeedToShow > numChildrenShown) {
+                setNumChildrenShown(numChildrenWeNeedToShow);
+            }
+        }
+
+        // Track scrolling
+        window.addEventListener("scroll", onScrollY);
+
+        // Cleanup
+        return () => window.removeEventListener("scroll", onScrollY);
+    }, [childHeight, childWidth, viewWidth, viewHeight, numChildrenShown]);
+
+    return children.slice(0, numChildrenShown);
+}
+
+export default LazyLoad;

--- a/src/components/Templates/LazyLoad.js
+++ b/src/components/Templates/LazyLoad.js
@@ -16,27 +16,59 @@ function LazyLoad(
     const childrenPerRow = useMemo(() => Math.floor(viewWidth/childWidth), [viewWidth, childWidth]);
     const height = useMemo(() => (children.length/childrenPerRow * childHeight), [children, childrenPerRow, childHeight]);
 
-    // Add listener for Y scrolling
+    // Add listener for Y scrolling on page load or resize
     useEffect(() => {
+        
+        // Watch for scrolling and compute number of children to show
         function onScrollY() {
 
-            // Calculate number of children to show
-            const numChildrenWeNeedToShow = Math.ceil((window.scrollY + viewHeight) / childHeight) * childrenPerRow;
+            throttle(() => { // Function to throttle
 
-            // Increment number of children to show if user scrolls down
-            if (numChildrenWeNeedToShow > numChildrenShown) {
-                setNumChildrenShown(numChildrenWeNeedToShow);
+                // Calculate number of children to show
+                const numChildrenWeNeedToShow = Math.ceil((window.scrollY + viewHeight) / childHeight) * childrenPerRow;
+    
+                // Increment number of children to show if user scrolls down
+                if (numChildrenWeNeedToShow > numChildrenShown) {
+                    setNumChildrenShown(numChildrenWeNeedToShow);
+                }
+
+            }, 200); // Delay
+
+        }
+
+        // Create a timer id
+        let id;
+
+        // Throttle scrolling event function
+        function throttle(throttledFunction, delay) {
+
+            // Do nothing if the timeout hasn't completed yet (otherwise id would be undefined)
+            if (id) {
+                return;
             }
+
+            // Call {throttledFunction} after {delay} and set timeout id
+            id = setTimeout(() => {
+
+                // Run the throttled function after the delay
+                throttledFunction();
+
+                // And clear the timer id
+                id = undefined;
+            }, delay);
         }
 
         //TODO: clean up event listener when done, call less often?, load more than a row at a time?, track scrollY?
 
         // Track scrolling
         window.addEventListener("scroll", onScrollY);
-
+        
         // Cleanup
         return () => window.removeEventListener("scroll", onScrollY);
-    }, [childHeight, viewHeight, childrenPerRow, numChildrenShown]);
+
+    }, [childHeight, childrenPerRow, numChildrenShown, viewHeight]);
+    
+    
 
     // Set height of lazyload div so scroll bar shows true length
     return <div className="lazyLoad" style={{ "height" : {height} }} >

--- a/src/css/CardList.css
+++ b/src/css/CardList.css
@@ -28,6 +28,7 @@ p#displayingNumberCards {
 .cardList-cards .lazyLoad {
     display: flex;
     flex-wrap: wrap;
+    align-content: flex-start;
     justify-content: center;
     gap: 0px 20px;
     margin: 0 20px;

--- a/src/css/CardList.css
+++ b/src/css/CardList.css
@@ -25,7 +25,7 @@ p#displayingNumberCards {
     transform: translateY(-3px);
 }
 
-.cardList-cards {
+.cardList-cards .lazyLoad {
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
@@ -33,7 +33,7 @@ p#displayingNumberCards {
     margin: 0 20px;
 }
 
-.cardList-cards>.bouncy.column {
+.cardList-cards .bouncy.column {
     width: 225px;
 }
 


### PR DESCRIPTION
Lazy load component for CardList, but should be implemented to allow for use basically anywhere.

- Tracks scrolling and screen resizing to calculate how many child elements are visible within the current view.
- Children are not rendered to the DOM at all until within about one 'view height' of the current view.
- Default view is the current window.
- Scroll listener is throttled to ~10% to avoid costly computations making the computer lag